### PR TITLE
[add] ルーム管理機能、ルーム内でのjsonの送受信

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -2,39 +2,49 @@ import socketio
 import time
 from datetime import datetime
 import json
+import argparse
 
 json_open = open('test.json', 'r')
 content = json.load(json_open)
 
+# 時間付きでの出力
+def print_log(message):
+    print('[{}] {}'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message))
+
 # 名前空間を設定するクラス
 class MyCustomNamespace(socketio.ClientNamespace): 
     def on_connect(self):
-        print('[{}] connect'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
+        print_log('connect')
 
     def on_disconnect(self):
-        print('[{}] disconnect'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
+        print_log('disconnect')
+
+    # def on_enter_room(self, room):
+    #     self.emit('send_roomid', room)
+    #     print_log('enter room:'+room)
 
     def on_response(self, msg):
-        print('[{}] response : {}'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S') , msg))
+        print_log('response : {}'.format(msg))
 
     # jsonが送られてきたときの処理
     def on_receive_content(self, content):
-        print('[{}] json response : {}'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S') , content))
+        print_log('json response : {}'.format(content))
 
 
 
 
 class SocketIOClient:
     
-    def __init__(self, host, path):
+    def __init__(self, host, path, roomId):
         self.host = host 
         self.path = path
         self.sio = socketio.Client()
+        self.roomId = roomId
     
     def connect(self):
-
         self.sio.register_namespace(MyCustomNamespace(self.path)) # 名前空間を設定
         self.sio.connect(self.host) # サーバーに接続
+        self.sio.emit('enter_room', self.roomId, namespace = self.path) # ルームIDを指定して入室
         self.sio.start_background_task(self.my_background_task, 123) # バックグラウンドタスクの登録 (123は引数の書き方の参考のため、処理には使っていない)
         self.sio.wait() # イベントが待ち
         
@@ -43,13 +53,30 @@ class SocketIOClient:
             input_data = input("send data:") # ターミナルから入力された文字を取得
 
             if input_data == 'send json':
-                self.sio.emit('send_json', content, namespace = self.path)
+                # jsonを送信する
+                data = {
+                    "roomId": self.roomId,
+                    "content": content
+                }
+                self.sio.emit('send_json', data, namespace = self.path)
             elif input_data == 'receive json':
+                # jsonを受信する
                 self.sio.emit('receive_json', namespace = self.path)
             else:
-                self.sio.emit('broadcast_message', input_data, namespace = self.path) # ターミナルで入力された文字をサーバーに送信
+                # メッセージを送信する
+                data = {
+                    "roomId": self.roomId,
+                    "content": input_data
+                }
+                self.sio.emit('broadcast_message', data, namespace = self.path) # ターミナルで入力された文字をサーバーに送信
             self.sio.sleep(1)
 
 if __name__ == '__main__':
-    sio_client = SocketIOClient('http://localhost:5000', '/test') # SocketIOClientクラスをインスタンス化
+    # roomIDを取得
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', '--room', type=str)
+    args = parser.parse_args()
+    print_log(args.room)
+
+    sio_client = SocketIOClient('http://localhost:5000', '/test', args.room) # SocketIOClientクラスをインスタンス化
     sio_client.connect()

--- a/python/client.py
+++ b/python/client.py
@@ -12,7 +12,7 @@ def print_log(message):
     print('[{}] {}'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message))
 
 # 名前空間を設定するクラス
-class MyCustomNamespace(socketio.ClientNamespace): 
+class MyCustomNamespace(socketio.ClientNamespace):
     def on_connect(self):
         print_log('connect')
 
@@ -34,20 +34,20 @@ class MyCustomNamespace(socketio.ClientNamespace):
 
 
 class SocketIOClient:
-    
+
     def __init__(self, host, path, roomId):
-        self.host = host 
+        self.host = host
         self.path = path
         self.sio = socketio.Client()
         self.roomId = roomId
-    
+
     def connect(self):
         self.sio.register_namespace(MyCustomNamespace(self.path)) # 名前空間を設定
         self.sio.connect(self.host) # サーバーに接続
         self.sio.emit('enter_room', self.roomId, namespace = self.path) # ルームIDを指定して入室
         self.sio.start_background_task(self.my_background_task, 123) # バックグラウンドタスクの登録 (123は引数の書き方の参考のため、処理には使っていない)
         self.sio.wait() # イベントが待ち
-        
+
     def my_background_task(self, my_argument): # ここにバックグランド処理のコードを書く
         while True:
             input_data = input("send data:") # ターミナルから入力された文字を取得

--- a/python/server.py
+++ b/python/server.py
@@ -21,7 +21,7 @@ clients = {}
 '''
 
 # 名前空間を設定するクラス
-class MyCustomNamespace(socketio.Namespace): 
+class MyCustomNamespace(socketio.Namespace):
 
     # クライアントが接続したときに実行される関数
     def on_connect(self, sid, environ):
@@ -35,15 +35,15 @@ class MyCustomNamespace(socketio.Namespace):
             clients[roomId] = []
         clients[roomId].append(sid)
         print_log('enter room: {}'.format(roomId))
-            
+
     # 送信してきたクライアントだけにメッセージを送る関数
-    def on_sid_message(self, sid, msg): 
+    def on_sid_message(self, sid, msg):
         self.emit('response', msg, room=sid)
         print_log('emit sid : {}'.format(msg))
 
     # 送信してきたクライアントを除く同じルームのクライアントにメッセージを送信する関数
     def on_skip_sid_message(self, sid, data):
-        self.emit('response', data["content"], room=data["roomId"], skip_sid=sid) 
+        self.emit('response', data["content"], room=data["roomId"], skip_sid=sid)
         print_log('emit skip sid : {}'.format(data["content"]))
 
     # 同じルームのすべてのクライアントにメッセージを送る関数
@@ -60,24 +60,24 @@ class MyCustomNamespace(socketio.Namespace):
     def on_receive_json(self, sid):
         self.emit('receive_content', content, room=sid)
         print_log('emit sid : {}'.format(content))
-    
+
     # クライアントとの接続が切れたときに実行される関数
     def on_disconnect(self, sid):
         print_log('disconnect')
 
 class SocketIOServer:
-    
+
     def __init__(self, host, port, path):
-        self.host = host 
+        self.host = host
         self.port = port
         self.path = path
         self.sio = socketio.Server(cors_allowed_origins='*') # CORSのエラーを無視する設定
 
-    
+
     def start(self, roomId):
         self.sio.register_namespace(MyCustomNamespace(self.path)) # 名前空間を設定
         app = socketio.WSGIApp(self.sio) # wsgiサーバーミドルウェア生成
-        self.sio.start_background_task(self.actively_send_json, roomId) # バックグラウンドタスクの登録 
+        self.sio.start_background_task(self.actively_send_json, roomId) # バックグラウンドタスクの登録
         eventlet.wsgi.server(eventlet.listen((self.host, self.port)), app) # wsgiサーバー起動
 
     # 能動的にjsonを送信する
@@ -86,7 +86,7 @@ class SocketIOServer:
             self.sio.sleep(3)
             print_log('emit json actively in {}'.format(roomId))
             self.sio.emit('receive_content', content, room="123", namespace='/test')
-    
+
 if __name__ == '__main__':
     sio_server = SocketIOServer('localhost', 5000, '/test') # SocketIOClientクラスをインスタンス化
     sio_server.start("123") # サーバーを起動する（引数はjsonを送信するルームID）


### PR DESCRIPTION
個々のメソッドを作った訳ではないですが、機能自体は下のような感じで達成できることは確認しました。

- ルームごとにjsonを送る: self.emit('response', msg, room=roomId)
(roomにroomIdを指定する.)

- 特定のクライアントにjsonを送る: self.emit('response', msg, room=clients[roomId][0])
(roomにクライアントのsidを指定する.)

- ルーム内の特定のクライアント以外のクライアントにjsonを送る: self.emit('response', msg, room=roomId, skip_sid=clients[roomId][0])
(roomにroomId, skip_sidにクライアントのsidを指定する.)