### PR TITLE
プレイヤーの名前の送受信

### DIFF
--- a/python/client/client.py
+++ b/python/client/client.py
@@ -140,7 +140,11 @@ class SocketIOClient:
         p.start()
 
     def enter_room(self):
-        self.sio_.emit('enter_room', self.room_id, namespace = self.namespace_, ) # ルームIDを指定して入室
+        data = {
+            'room_id': self.room_id,
+            'player_name': self.player_name,
+        }
+        self.sio_.emit('enter_room', data=data, namespace = self.namespace_, ) # ルームIDを指定して入室
 
 
 class RandomAgent(mjx.Agent):

--- a/python/client/client.py
+++ b/python/client/client.py
@@ -64,7 +64,7 @@ class SocketIOClient:
         self.Namespace.on_server_to_client = self.on_server_to_client
         self.Namespace.on_ask_act = self.on_ask_act
     # 初期化
-    def __init__(self,ip,port,namespace,query,agent,room_id):
+    def __init__(self,ip,port,namespace,query,agent,room_id,player_name):
         self.ip_         = ip
         self.port_       = port
         self.namespace_  = namespace
@@ -76,6 +76,7 @@ class SocketIOClient:
         self.sio_.register_namespace(self.Namespace)
         self.agent = agent
         self.room_id = room_id
+        self.player_name = player_name
     # 接続確認
     def isConnect(self):
         return self.is_connect_

--- a/python/sample_client.py
+++ b/python/sample_client.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
         query='secret',
         agent=my_agent,  # プレイヤーの指定
         room_id=123,  # 部屋のID．4人で対局させる時は，同じIDを指定する．
+        player_name='hogehoge' # プレイヤーの名前
         )
     # SocketIO Client インスタンスを実行
     sio_client.run()


### PR DESCRIPTION
以下に沿って実装しました。

-  サーバーへの接続時に，クライアントが自分の名前を送信する
    - JMAC_2023_spring 最新からブランチ切る
    - client.client.SocketIOClient のコンストラクタで， player_name として受け取る
- サーバーは，クライアントのsidと名前をセットで保持
    - JMAC_2023_spring 最新からブランチ切る
    - server.server.SocketIOServer のプロパティ
        - コンストラクタで self.player_names = {}
        - self.player_names[roomId] = {sid: ”名前”, sid: ”名前”, sid: ”名前”, sid: ”名前”}